### PR TITLE
Added a BoardGenerator Interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,13 @@ include_directories(include)
 # Libraries
 add_library(Board_lib src/Board.cpp)
 add_library(Game_lib src/Game.cpp)
+add_library(RandomBoardGenerator_lib src/RandomBoardGenerator.cpp)
 
 target_link_libraries(Game_lib
                     Board_lib)
+
+target_link_libraries(RandomBoardGenerator_lib
+                      Board_lib)
 
 add_executable(nonogram src/main.cpp)
 
@@ -56,4 +60,10 @@ target_link_libraries(Board_test
                       Board_lib
                       gtest_main)
 
+add_executable(RandomBoardGenerator_test tests/RandomBoardGeneratorTest.cpp)
+target_link_libraries(RandomBoardGenerator_test
+                      RandomBoardGenerator_lib
+                      gtest_main)
+
 gtest_discover_tests(Board_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+gtest_discover_tests(RandomBoardGenerator_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)

--- a/include/Board.h
+++ b/include/Board.h
@@ -8,7 +8,7 @@
 
 class Board {
 public:
-    Board(std::unique_ptr<BoardData> b);
+    Board(u_ptr<BoardData> b);
 
     // Returns if the provided move is valid or not.
     bool fill(const FillDirection& d, const Point& start, const Point& end, const Cell& type);
@@ -19,7 +19,7 @@ public:
 private:
     int m_cols;
     int m_rows;
-    std::unique_ptr<BoardData> m_board;
+    u_ptr<BoardData> m_board;
 };
 
 inline

--- a/include/Board.h
+++ b/include/Board.h
@@ -8,7 +8,7 @@
 
 class Board {
 public:
-    Board(std::unique_ptr<std::vector<std::vector<Cell>>> b);
+    Board(std::unique_ptr<BoardData> b);
 
     // Returns if the provided move is valid or not.
     bool fill(const FillDirection& d, const Point& start, const Point& end, const Cell& type);
@@ -19,7 +19,7 @@ public:
 private:
     int m_cols;
     int m_rows;
-    std::unique_ptr<std::vector<std::vector<Cell>>> m_board;
+    std::unique_ptr<BoardData> m_board;
 };
 
 inline

--- a/include/Board.h
+++ b/include/Board.h
@@ -4,23 +4,38 @@
 #include "Utility.h"
 
 #include <vector>
+#include <memory>
 
 class Board {
 public:
-    Board(std::vector<std::vector<Cell>>* b);
+    Board(std::unique_ptr<std::vector<std::vector<Cell>>> b);
 
     // Returns if the provided move is valid or not.
     bool fill(const FillDirection& d, const Point& start, const Point& end, const Cell& type);
-    std::vector<std::vector<Cell>>* getVector();
+
+    std::vector<Cell> getRow(int row);
+
+    std::vector<Cell> getColumn(int column);
 private:
     int m_cols;
     int m_rows;
-    std::vector<std::vector<Cell>>* m_board;
+    std::unique_ptr<std::vector<std::vector<Cell>>> m_board;
 };
 
 inline
-std::vector<std::vector<Cell>>* Board::getVector() {
-    return m_board;
+std::vector<Cell> Board::getRow(int row) {
+    return (*m_board)[row];
+}
+
+inline
+std::vector<Cell> Board::getColumn(int column) {
+    std::vector<Cell> col;
+
+    for (auto row : *m_board) {
+        col.push_back(row[column]);
+    }
+
+    return col;
 }
 
 #endif

--- a/include/BoardGenerator.h
+++ b/include/BoardGenerator.h
@@ -8,7 +8,7 @@
 
 class BoardGenerator {
 public:
-    virtual Result<std::unique_ptr<Board>> generateBoard(int rows, int columns, double probOfFilled) = 0;
+    virtual Result<u_ptr<Board>> generateBoard(int rows, int columns, double probOfFilled) = 0;
 };
 
 #endif

--- a/include/BoardGenerator.h
+++ b/include/BoardGenerator.h
@@ -1,0 +1,8 @@
+#include "Board.h"
+
+#include <memory>
+
+class BoardGenerator {
+public:
+    virtual std::unique_ptr<Board> generateBoard(int rows, int columns, double probOfFilled) = 0;
+};

--- a/include/BoardGenerator.h
+++ b/include/BoardGenerator.h
@@ -8,7 +8,7 @@
 
 class BoardGenerator {
 public:
-    virtual Result<u_ptr<Board>> generateBoard(int rows, int columns, double probOfFilled) = 0;
+    virtual Result<u_ptr<Board>> generateBoard(int rows, int columns) = 0;
 };
 
 #endif

--- a/include/FakeBoardGenerator.h
+++ b/include/FakeBoardGenerator.h
@@ -1,5 +1,5 @@
-#ifndef RANDOM_BOARD_GENERATOR_H
-#define RANDOM_BOARD_GENERATOR_H
+#ifndef FAKE_BOARD_GENERATOR_H
+#define FAKE_BOARD_GENERATOR_H
 
 #include "BoardGenerator.h"
 #include "Board.h"
@@ -7,7 +7,7 @@
 
 #include <memory>
 
-class RandomBoardGenerator : BoardGenerator {
+class FakeBoardGenerator : BoardGenerator {
 public:
     virtual Result<std::unique_ptr<Board>> generateBoard(int rows, int columns, double probOfFilled);
 };

--- a/include/FakeBoardGenerator.h
+++ b/include/FakeBoardGenerator.h
@@ -9,7 +9,7 @@
 
 class FakeBoardGenerator : BoardGenerator {
 public:
-    virtual Result<std::unique_ptr<Board>> generateBoard(int rows, int columns, double probOfFilled);
+    virtual Result<u_ptr<Board>> generateBoard(int rows, int columns, double probOfFilled);
 };
 
 #endif

--- a/include/FakeBoardGenerator.h
+++ b/include/FakeBoardGenerator.h
@@ -5,11 +5,11 @@
 #include "Board.h"
 #include "Utility.h"
 
-#include <memory>
+#include <functional>
 
 class FakeBoardGenerator : BoardGenerator {
 public:
-    virtual Result<u_ptr<Board>> generateBoard(int rows, int columns, double probOfFilled);
+    virtual Result<u_ptr<Board>> generateBoard(int rows, int columns, double probOfFilled, std::function<double()> rng);
 };
 
 #endif

--- a/include/RandomBoardGenerator.h
+++ b/include/RandomBoardGenerator.h
@@ -6,10 +6,15 @@
 #include "Utility.h"
 
 #include <memory>
+#include <random>
 
 class RandomBoardGenerator : BoardGenerator {
 public:
-    virtual Result<std::unique_ptr<Board>> generateBoard(int rows, int columns, double probOfFilled);
+    RandomBoardGenerator(u_ptr<std::mt19937> rng, u_ptr<std::uniform_real_distribution<double>> distr);
+    virtual Result<u_ptr<Board>> generateBoard(int rows, int columns, double probOfFilled);
+private:
+    u_ptr<std::mt19937> m_rng; 
+    u_ptr<std::uniform_real_distribution<double>> m_distr;
 };
 
 #endif

--- a/include/RandomBoardGenerator.h
+++ b/include/RandomBoardGenerator.h
@@ -1,12 +1,13 @@
-#ifndef BOARD_GENERATOR_H
-#define BOARD_GENERATOR_H
+#ifndef RANDOM_BOARD_GENERATOR_H
+#define RANDOM_BOARD_GENERATOR_H
 
+#include "BoardGenerator.h"
 #include "Board.h"
 #include "Utility.h"
 
 #include <memory>
 
-class BoardGenerator {
+class RandomBoardGenerator : BoardGenerator {
 public:
     virtual Result<std::unique_ptr<Board>> generateBoard(int rows, int columns, double probOfFilled) = 0;
 };

--- a/include/RandomBoardGenerator.h
+++ b/include/RandomBoardGenerator.h
@@ -7,14 +7,15 @@
 
 #include <memory>
 #include <random>
+#include <functional>
 
 class RandomBoardGenerator : BoardGenerator {
 public:
-    RandomBoardGenerator(u_ptr<std::mt19937> rng, u_ptr<std::uniform_real_distribution<double>> distr);
-    virtual Result<u_ptr<Board>> generateBoard(int rows, int columns, double probOfFilled);
+    RandomBoardGenerator(double probOfFilled, std::function<double()> rng);
+    virtual Result<u_ptr<Board>> generateBoard(int rows, int columns);
 private:
-    u_ptr<std::mt19937> m_rng; 
-    u_ptr<std::uniform_real_distribution<double>> m_distr;
+    double m_probOfFilled;
+    std::function<double()> m_rng;
 };
 
 #endif

--- a/include/Utility.h
+++ b/include/Utility.h
@@ -5,6 +5,7 @@ Holds constants and other useful constructs used throughout the program.
 #ifndef UTILITY_H
 #define UTILITY_H
 
+#include <vector>
 #include <utility>
 
 // Cell::FILLED represents a filled in cell. Cell::EMPTY represents a cell that has not been modified yet. /
@@ -24,5 +25,10 @@ enum class FillDirection {
 };
 
 using Point = std::pair<int, int>;
+
+using BoardData = std::vector<std::vector<Cell>>;
+
+template <typename T>
+using Result = std::pair<T, bool>;
 
 #endif

--- a/include/Utility.h
+++ b/include/Utility.h
@@ -7,6 +7,7 @@ Holds constants and other useful constructs used throughout the program.
 
 #include <vector>
 #include <utility>
+#include <memory>
 
 // Cell::FILLED represents a filled in cell. Cell::EMPTY represents a cell that has not been modified yet. /
 // Cell::NOTHING represents a cell that has been determined to be empty. Cell::TEST represents a cell that /
@@ -30,5 +31,8 @@ using BoardData = std::vector<std::vector<Cell>>;
 
 template <typename T>
 using Result = std::pair<T, bool>;
+
+template <typename T>
+using u_ptr = std::unique_ptr<T>;
 
 #endif

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -2,9 +2,11 @@
 #include "Utility.h"
 
 #include <vector>
+#include <memory>
+#include <utility>
 
-Board::Board(std::vector<std::vector<Cell>>* b) {
-    m_board = b;
+Board::Board(std::unique_ptr<std::vector<std::vector<Cell>>> b) {
+    m_board = std::move(b);
     m_rows = m_board->size();
     m_cols = (*m_board)[0].size();
 }

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -5,7 +5,7 @@
 #include <memory>
 #include <utility>
 
-Board::Board(std::unique_ptr<BoardData> b) {
+Board::Board(u_ptr<BoardData> b) {
     m_board = std::move(b);
     m_rows = m_board->size();
     m_cols = (*m_board)[0].size();

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -5,7 +5,7 @@
 #include <memory>
 #include <utility>
 
-Board::Board(std::unique_ptr<std::vector<std::vector<Cell>>> b) {
+Board::Board(std::unique_ptr<BoardData> b) {
     m_board = std::move(b);
     m_rows = m_board->size();
     m_cols = (*m_board)[0].size();

--- a/src/FakeBoardGenerator.cpp
+++ b/src/FakeBoardGenerator.cpp
@@ -1,0 +1,26 @@
+#include "FakeBoardGenerator.h"
+#include "Board.h"
+#include "Utility.h"
+
+#include <vector>
+#include <memory>
+
+// Returns a board with the diagonal filled for testing purposes.
+Result<std::unique_ptr<Board>> FakeBoardGenerator::generateBoard(int rows, int columns, double probOfFilled) {
+    if (rows <= 0 || columns <= 0 || probOfFilled < 0 || probOfFilled > 1) {
+        return {nullptr, false};
+    }
+
+    std::unique_ptr<BoardData> boardData(new BoardData());
+
+    for (int i = 0; i < rows; i++) {
+        std::vector<Cell> row;
+        for (int j = 0; j < columns; j++) {
+            row.push_back(i == j ? Cell::FILLED : Cell::NOTHING);
+        }
+
+        boardData->push_back(row);
+    }
+
+    return {std::unique_ptr<Board>(new Board(std::move(boardData))), true};
+}

--- a/src/FakeBoardGenerator.cpp
+++ b/src/FakeBoardGenerator.cpp
@@ -6,12 +6,12 @@
 #include <memory>
 
 // Returns a board with the diagonal filled for testing purposes.
-Result<std::unique_ptr<Board>> FakeBoardGenerator::generateBoard(int rows, int columns, double probOfFilled) {
+Result<u_ptr<Board>> FakeBoardGenerator::generateBoard(int rows, int columns, double probOfFilled) {
     if (rows <= 0 || columns <= 0 || probOfFilled < 0 || probOfFilled > 1) {
         return {nullptr, false};
     }
 
-    std::unique_ptr<BoardData> boardData(new BoardData());
+    u_ptr<BoardData> boardData(new BoardData());
 
     for (int i = 0; i < rows; i++) {
         std::vector<Cell> row;
@@ -22,5 +22,5 @@ Result<std::unique_ptr<Board>> FakeBoardGenerator::generateBoard(int rows, int c
         boardData->push_back(row);
     }
 
-    return {std::unique_ptr<Board>(new Board(std::move(boardData))), true};
+    return {u_ptr<Board>(new Board(std::move(boardData))), true};
 }

--- a/src/FakeBoardGenerator.cpp
+++ b/src/FakeBoardGenerator.cpp
@@ -3,10 +3,10 @@
 #include "Utility.h"
 
 #include <vector>
-#include <memory>
+#include <functional>
 
 // Returns a board with the diagonal filled for testing purposes.
-Result<u_ptr<Board>> FakeBoardGenerator::generateBoard(int rows, int columns, double probOfFilled) {
+Result<u_ptr<Board>> FakeBoardGenerator::generateBoard(int rows, int columns, double probOfFilled, std::function<double()> rng) {
     if (rows <= 0 || columns <= 0 || probOfFilled < 0 || probOfFilled > 1) {
         return {nullptr, false};
     }

--- a/src/RandomBoardGenerator.cpp
+++ b/src/RandomBoardGenerator.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 #include <memory>
 #include <random>
-#include <utility>
 
 // Returns a result object that tells whether the returned pointer is valid or not.
 Result<std::unique_ptr<Board>> RandomBoardGenerator::generateBoard(int rows, int columns, double probOfFilled) {
@@ -13,8 +12,8 @@ Result<std::unique_ptr<Board>> RandomBoardGenerator::generateBoard(int rows, int
         return {nullptr, false};
     }
 
-    std::vector<Cell> emptyRow = std::vector<Cell>(columns, Cell::EMPTY);
-    std::unique_ptr<BoardData> boardData = std::unique_ptr<BoardData>(new BoardData(rows, emptyRow));
+    std::vector<Cell> emptyRow(columns, Cell::NOTHING);
+    std::unique_ptr<BoardData> boardData(new BoardData(rows, emptyRow));
 
     // Initialize random number generator from a uniform distribution.
     std::random_device rd;

--- a/src/RandomBoardGenerator.cpp
+++ b/src/RandomBoardGenerator.cpp
@@ -1,0 +1,33 @@
+#include "RandomBoardGenerator.h"
+#include "Board.h"
+#include "Utility.h"
+
+#include <vector>
+#include <memory>
+#include <random>
+#include <utility>
+
+// Returns a result object that tells whether the returned pointer is valid or not.
+Result<std::unique_ptr<Board>> RandomBoardGenerator::generateBoard(int rows, int columns, double probOfFilled) {
+    if (rows <= 0 || columns <= 0 || probOfFilled < 0 || probOfFilled > 1) {
+        return {nullptr, false};
+    }
+
+    std::vector<Cell> emptyRow = std::vector<Cell>(columns, Cell::EMPTY);
+    std::unique_ptr<BoardData> boardData = std::unique_ptr<BoardData>(new BoardData(rows, emptyRow));
+
+    // Initialize random number generator from a uniform distribution.
+    std::random_device rd;
+    std::mt19937 rng(rd());
+    std::uniform_real_distribution distr(0.0, 1.0);
+
+    for (auto &row : *boardData) {
+        for (auto &cell : row) {
+            if (distr(rng) < probOfFilled) {
+                cell = Cell::FILLED;
+            }
+        }
+    }
+
+    return {std::unique_ptr<Board>(new Board(std::move(boardData))), true};
+}

--- a/src/RandomBoardGenerator.cpp
+++ b/src/RandomBoardGenerator.cpp
@@ -6,27 +6,29 @@
 #include <memory>
 #include <random>
 
+RandomBoardGenerator::RandomBoardGenerator(u_ptr<std::mt19937> rng, u_ptr<std::uniform_real_distribution<double>> distr) : BoardGenerator() {
+    m_rng = std::move(rng);
+    m_distr = std::move(distr);
+}
+
 // Returns a result object that tells whether the returned pointer is valid or not.
-Result<std::unique_ptr<Board>> RandomBoardGenerator::generateBoard(int rows, int columns, double probOfFilled) {
+Result<u_ptr<Board>> RandomBoardGenerator::generateBoard(int rows, int columns, double probOfFilled) {
     if (rows <= 0 || columns <= 0 || probOfFilled < 0 || probOfFilled > 1) {
         return {nullptr, false};
     }
 
     std::vector<Cell> emptyRow(columns, Cell::NOTHING);
-    std::unique_ptr<BoardData> boardData(new BoardData(rows, emptyRow));
+    u_ptr<BoardData> boardData(new BoardData(rows, emptyRow));
 
     // Initialize random number generator from a uniform distribution.
-    std::random_device rd;
-    std::mt19937 rng(rd());
-    std::uniform_real_distribution distr(0.0, 1.0);
 
     for (auto &row : *boardData) {
         for (auto &cell : row) {
-            if (distr(rng) < probOfFilled) {
+            if ((*m_distr)(*m_rng) < probOfFilled) {
                 cell = Cell::FILLED;
             }
         }
     }
 
-    return {std::unique_ptr<Board>(new Board(std::move(boardData))), true};
+    return {u_ptr<Board>(new Board(std::move(boardData))), true};
 }

--- a/src/RandomBoardGenerator.cpp
+++ b/src/RandomBoardGenerator.cpp
@@ -5,29 +5,34 @@
 #include <vector>
 #include <memory>
 #include <random>
+#include <functional>
+#include <iostream>
 
-RandomBoardGenerator::RandomBoardGenerator(u_ptr<std::mt19937> rng, u_ptr<std::uniform_real_distribution<double>> distr) : BoardGenerator() {
-    m_rng = std::move(rng);
-    m_distr = std::move(distr);
+RandomBoardGenerator::RandomBoardGenerator(double probOfFilled, std::function<double()> rng) : BoardGenerator() {
+    m_probOfFilled = probOfFilled;
+    m_rng = rng;
 }
 
 // Returns a result object that tells whether the returned pointer is valid or not.
-Result<u_ptr<Board>> RandomBoardGenerator::generateBoard(int rows, int columns, double probOfFilled) {
-    if (rows <= 0 || columns <= 0 || probOfFilled < 0 || probOfFilled > 1) {
+Result<u_ptr<Board>> RandomBoardGenerator::generateBoard(int rows, int columns) {
+    if (rows <= 0 || columns <= 0 || m_probOfFilled < 0 || m_probOfFilled > 1) {
         return {nullptr, false};
     }
 
-    std::vector<Cell> emptyRow(columns, Cell::NOTHING);
-    u_ptr<BoardData> boardData(new BoardData(rows, emptyRow));
+    // Intialize empty board vector
+    u_ptr<BoardData> boardData(new BoardData(rows));
 
-    // Initialize random number generator from a uniform distribution.
+    for (int i = 0; i < rows; i++) {
+        std::vector<Cell> row(columns, Cell::NOTHING);
 
-    for (auto &row : *boardData) {
-        for (auto &cell : row) {
-            if ((*m_distr)(*m_rng) < probOfFilled) {
+        // Fill in each column according to RNG
+        for (Cell &cell : row) {
+            if (m_rng() < m_probOfFilled) {
                 cell = Cell::FILLED;
             }
         }
+
+        (*boardData)[i].swap(row);
     }
 
     return {u_ptr<Board>(new Board(std::move(boardData))), true};

--- a/tests/BoardTest.cpp
+++ b/tests/BoardTest.cpp
@@ -9,10 +9,10 @@
 
 class BoardTest : public ::testing::Test {
 protected:
-    std::unique_ptr<std::vector<std::vector<Cell>>> boardVector;
+    u_ptr<std::vector<std::vector<Cell>>> boardVector;
 
     void SetUp() override {
-        boardVector = std::unique_ptr<std::vector<std::vector<Cell>>>(new std::vector<std::vector<Cell>>);
+        boardVector = u_ptr<std::vector<std::vector<Cell>>>(new std::vector<std::vector<Cell>>);
         boardVector->emplace_back(3, Cell::EMPTY);
         boardVector->emplace_back(3, Cell::EMPTY);
         boardVector->emplace_back(3, Cell::EMPTY);

--- a/tests/BoardTest.cpp
+++ b/tests/BoardTest.cpp
@@ -4,48 +4,57 @@
 #include "Utility.h"
 #include <vector>
 #include <iostream>
+#include <memory>
+#include <utility>
 
 class BoardTest : public ::testing::Test {
 protected:
-    std::vector<std::vector<Cell>> boardVector;
+    std::unique_ptr<std::vector<std::vector<Cell>>> boardVector;
 
     void SetUp() override {
-        boardVector.emplace_back(3, Cell::EMPTY);
-        boardVector.emplace_back(3, Cell::EMPTY);
-        boardVector.emplace_back(3, Cell::EMPTY);
+        boardVector = std::unique_ptr<std::vector<std::vector<Cell>>>(new std::vector<std::vector<Cell>>);
+        boardVector->emplace_back(3, Cell::EMPTY);
+        boardVector->emplace_back(3, Cell::EMPTY);
+        boardVector->emplace_back(3, Cell::EMPTY);
     }
 };
 
 TEST_F(BoardTest, ConstructorTest) {
-    Board b(&boardVector);
+    Board b(std::move(boardVector));
 
-    EXPECT_EQ(b.getVector(), &boardVector);
+    //EXPECT_EQ(b.getVector(), &boardVector);
 }
 
 TEST_F(BoardTest, FillRowTest) {
-    Board b(&boardVector);
+    Board b(std::move(boardVector));
 
     EXPECT_TRUE(b.fill(FillDirection::ROW, {0, 0}, {0, 2}, Cell::FILLED));
 
+    std::vector<Cell> boardRow = b.getRow(0);
+
     for (int i = 0; i < 3; i++) {
-        EXPECT_EQ(boardVector[0][i], Cell::FILLED);
+        EXPECT_EQ(boardRow[i], Cell::FILLED);
     }
 }
 
 TEST_F(BoardTest, FillColumnTest) {
-    Board b(&boardVector);
+    Board b(std::move(boardVector));
 
     EXPECT_TRUE(b.fill(FillDirection::COLUMN, {0, 0}, {2, 0}, Cell::FILLED));
 
+    std::vector<Cell> boardColumn = b.getColumn(0);
+
     for (int i = 0; i < 3; i++) {
-        EXPECT_EQ(boardVector[i][0], Cell::FILLED);
+        EXPECT_EQ(boardColumn[i], Cell::FILLED);
     }
 }
 
 TEST_F(BoardTest, FillCellTest) {
-    Board b(&boardVector);
+    Board b(std::move(boardVector));
 
     EXPECT_TRUE(b.fill(FillDirection::COLUMN, {0, 0}, {0, 0}, Cell::FILLED));
 
-    EXPECT_EQ(boardVector[0][0], Cell::FILLED);
+    std::vector<Cell> boardRow = b.getRow(0);
+
+    EXPECT_EQ(boardRow[0], Cell::FILLED);
 }

--- a/tests/BoardTest.cpp
+++ b/tests/BoardTest.cpp
@@ -4,7 +4,6 @@
 #include "Utility.h"
 #include <vector>
 #include <iostream>
-#include <memory>
 #include <utility>
 
 class BoardTest : public ::testing::Test {

--- a/tests/RandomBoardGeneratorTest.cpp
+++ b/tests/RandomBoardGeneratorTest.cpp
@@ -1,0 +1,107 @@
+#include <gtest/gtest.h>
+
+#include "RandomBoardGenerator.h"
+#include "Board.h"
+#include "Utility.h"
+#include <functional>
+#include <vector>
+#include <random>
+
+class RandomBoardGeneratorTest : public ::testing::Test {
+protected:
+    u_ptr<Board> board;
+    double probOfFilled;
+    int rows;
+    int cols;
+
+    std::random_device dev;
+    std::mt19937 rng_base;
+    std::uniform_real_distribution<> distr;
+
+    std::function<double()> rng;
+
+    void SetUp() override {
+        probOfFilled = 0.5;
+        rng_base = std::mt19937(dev());
+        rng = std::bind(distr, rng_base);
+        rows = 10;
+        cols = 10;
+    }
+};
+
+TEST_F(RandomBoardGeneratorTest, GenerateEmptyBoardProbZero) {
+    RandomBoardGenerator boardGenerator(0, rng);
+
+    Result<u_ptr<Board>> generationResult = boardGenerator.generateBoard(rows, cols);
+    EXPECT_TRUE(generationResult.second);
+
+    board = std::move(generationResult.first);
+
+    for (int i = 0; i < rows; i++) {
+        std::vector<Cell> row = board->getRow(i);
+
+        for (Cell c : row) {
+            EXPECT_EQ(c, Cell::NOTHING);
+        }
+    }
+}
+
+// RNG being 0 generates a full board.
+TEST_F(RandomBoardGeneratorTest, GenerateEmptyBoardRngZero) {
+    RandomBoardGenerator boardGenerator(probOfFilled, []() -> double {return 0.0;});
+
+    Result<u_ptr<Board>> generationResult = boardGenerator.generateBoard(rows, cols);
+    EXPECT_TRUE(generationResult.second);
+
+    board = std::move(generationResult.first);
+
+    for (int i = 0; i < rows; i++) {
+        std::vector<Cell> row = board->getRow(i);
+
+        for (Cell c : row) {
+            EXPECT_EQ(c, Cell::FILLED);
+        }
+    }
+}
+
+TEST_F(RandomBoardGeneratorTest, GenerateFullBoardProbOne) {
+    RandomBoardGenerator boardGenerator(1, rng);
+
+    Result<u_ptr<Board>> generationResult = boardGenerator.generateBoard(rows, cols);
+    EXPECT_TRUE(generationResult.second);
+
+    board = std::move(generationResult.first);
+
+    for (int i = 0; i < rows; i++) {
+        std::vector<Cell> row = board->getRow(i);
+
+        for (Cell c : row) {
+            EXPECT_EQ(c, Cell::FILLED);
+        }
+    }
+}
+
+// RNG being 1 generates an empty board.
+TEST_F(RandomBoardGeneratorTest, GenerateFullBoardRngOne) {
+    RandomBoardGenerator boardGenerator(probOfFilled, []() -> double {return 1.0;});
+
+    Result<u_ptr<Board>> generationResult = boardGenerator.generateBoard(rows, cols);
+    EXPECT_TRUE(generationResult.second);
+
+    board = std::move(generationResult.first);
+
+    for (int i = 0; i < rows; i++) {
+        std::vector<Cell> row = board->getRow(i);
+
+        for (Cell c : row) {
+            EXPECT_EQ(c, Cell::NOTHING);
+        }
+    }
+}
+
+TEST_F(RandomBoardGeneratorTest, GenerateRandomBoard) {
+    RandomBoardGenerator boardGenerator(probOfFilled, rng);
+
+    Result<u_ptr<Board>> generationResult = boardGenerator.generateBoard(rows, cols);
+    EXPECT_TRUE(generationResult.second);
+}


### PR DESCRIPTION
Added a BoardGenerator interface that specifies that a BoardGenerator should be able to return a generated Board.

Changed all raw pointers to unique pointers to make passing dynamically created objects easier. Updated all pointer copy instances to use move semantics instead.